### PR TITLE
Changes to fix segmentation faults on 64 bit platforms and update SSL support.

### DIFF
--- a/README
+++ b/README
@@ -65,9 +65,10 @@ Mac OSX
 To build on Mac OSX, first install brew, then:
 brew install openssl@1.1
 cd path_to_source
-export LDFLAGS=-L/usr/local/Cellar/openssl@1.1/1.1.1n/lib
-export CFLAGS=-I/usr/local/Cellar/openssl@1.1/1.1.1n/include
-./configure --with-ssl=/usr/local/Cellar/openssl@1.1/1.1.1n/include --build=x86_64-apple-darwin17.7.0 --without-python
+export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
+./configure --with-ssl --with-ssl=/usr/local/Cellar/openssl@1.1/1.1.1n --build=x86_64-apple-darwin17.7.0 --without-python $@
 make
 make install
 

--- a/README
+++ b/README
@@ -59,6 +59,22 @@ compile the source.  There have been both reports of the standard BSD curses
 working and not working, so you may have to install GNU curses (ncurses)
 under *BSD.
 
+Mac OSX
+=======
+
+To build on Mac OSX, first install brew, then:
+brew install openssl@1.1
+cd path_to_source
+export LDFLAGS=-L/usr/local/Cellar/openssl@1.1/1.1.1n/lib
+export CFLAGS=-I/usr/local/Cellar/openssl@1.1/1.1.1n/include
+./configure --with-ssl=/usr/local/Cellar/openssl@1.1/1.1.1n/include --build=x86_64-apple-darwin17.7.0 --without-python
+make
+make install
+
+Note that if OpenSSL is updated, the path to OpenSSL, which includes the
+OpenSSL version may change slightly. If so you will need to modify the above
+command appropriately.
+
 X Windows
 =========
 

--- a/configure
+++ b/configure
@@ -728,9 +728,10 @@ SHELL=${CONFIG_SHELL-/bin/sh}
 # Identity of this package.
 PACKAGE_NAME='tn5250'
 PACKAGE_TARNAME='tn5250'
-PACKAGE_VERSION='0.17.4'
-PACKAGE_STRING='tn5250 0.17.4'
-PACKAGE_BUGREPORT='linux5250@midrange.com'
+PACKAGE_VERSION='0.17.4.1'
+PACKAGE_STRING='tn5250 0.17.4.1'
+#PACKAGE_BUGREPORT='linux5250@midrange.com'
+PACKAGE_BUGREPORT='barry.nelson@amobiledevice.com'
 
 # Factoring default headers for most tests.
 ac_includes_default="\
@@ -2256,7 +2257,7 @@ fi
 
 # Define the identity of the package.
  PACKAGE='tn5250'
- VERSION='0.17.4'
+ VERSION='0.17.4.1'
 
 
 cat >>confdefs.h <<_ACEOF
@@ -8269,9 +8270,9 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
            allow_undefined_flag='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
          else
            case ${MACOSX_DEPLOYMENT_TARGET} in
-             10.[012])
-               allow_undefined_flag='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
-               ;;
+#             10.[012])
+#               allow_undefined_flag='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
+#               ;;
              10.*)
                allow_undefined_flag='${wl}-undefined ${wl}dynamic_lookup'
                ;;
@@ -11328,9 +11329,9 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
            allow_undefined_flag_CXX='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
          else
            case ${MACOSX_DEPLOYMENT_TARGET} in
-             10.[012])
-               allow_undefined_flag_CXX='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
-               ;;
+#             10.[012])
+#               allow_undefined_flag_CXX='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
+#               ;;
              10.*)
                allow_undefined_flag_CXX='${wl}-undefined ${wl}dynamic_lookup'
                ;;
@@ -14888,9 +14889,9 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
            allow_undefined_flag_F77='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
          else
            case ${MACOSX_DEPLOYMENT_TARGET} in
-             10.[012])
-               allow_undefined_flag_F77='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
-               ;;
+#             10.[012])
+#               allow_undefined_flag_F77='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
+#               ;;
              10.*)
                allow_undefined_flag_F77='${wl}-undefined ${wl}dynamic_lookup'
                ;;
@@ -17489,9 +17490,9 @@ if test -z "$aix_libpath"; then aix_libpath="/usr/lib:/lib"; fi
            allow_undefined_flag_GCJ='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
          else
            case ${MACOSX_DEPLOYMENT_TARGET} in
-             10.[012])
-               allow_undefined_flag_GCJ='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
-               ;;
+#             10.[012])
+#               allow_undefined_flag_GCJ='${wl}-flat_namespace ${wl}-undefined ${wl}suppress'
+#               ;;
              10.*)
                allow_undefined_flag_GCJ='${wl}-undefined ${wl}dynamic_lookup'
                ;;
@@ -23236,6 +23237,7 @@ fi
 echo $ECHO_N "checking whether to build with OpenSSL support... $ECHO_C" >&6; }
 if test "${ac_cv_use_ssl+set}" = set; then
   echo $ECHO_N "(cached) $ECHO_C" >&6
+  ac_cv_use_ssl=yes
 else
   ac_cv_use_ssl=yes
 fi
@@ -23244,6 +23246,12 @@ echo "${ECHO_T}$ac_cv_use_ssl" >&6; }
 
 if test "$ac_cv_use_ssl" = "yes"
 then
+#    cat >>confdefs.h <<_ACEOF
+##define HAVE_LIBSSL 1
+##define HAVE_LIBCRYPTO 1
+#_ACEOF
+#
+#    LIBS="-lssl -lcrypto $LIBS"
 checksslinclude() {
     if test -f "$1/include/openssl/ssl.h"; then
         sslincludedir="-I$1/include"
@@ -23298,6 +23306,7 @@ if test -n $sslincludedir; then
 echo $ECHO_N "checking for CRYPTO_num_locks in -lcrypto... $ECHO_C" >&6; }
 if test "${ac_cv_lib_crypto_CRYPTO_num_locks+set}" = set; then
   echo $ECHO_N "(cached) $ECHO_C" >&6
+  ac_cv_lib_crypto_CRYPTO_num_locks=yes
 else
   ac_check_lib_save_LIBS=$LIBS
 LIBS="-lcrypto  $LIBS"
@@ -23314,7 +23323,10 @@ cat >>conftest.$ac_ext <<_ACEOF
 #ifdef __cplusplus
 extern "C"
 #endif
+#include <openssl/crypto.h>
+#ifndef CRYPTO_num_locks
 char CRYPTO_num_locks ();
+#endif
 int
 main ()
 {
@@ -23375,6 +23387,7 @@ echo "$as_me: error: ** Unable to find OpenSSL libraries!" >&2;}
 echo $ECHO_N "checking for SSL_library_init in -lssl... $ECHO_C" >&6; }
 if test "${ac_cv_lib_ssl_SSL_library_init+set}" = set; then
   echo $ECHO_N "(cached) $ECHO_C" >&6
+  ac_cv_lib_ssl_SSL_library_init=yes
 else
   ac_check_lib_save_LIBS=$LIBS
 LIBS="-lssl  $LIBS"
@@ -23391,7 +23404,10 @@ cat >>conftest.$ac_ext <<_ACEOF
 #ifdef __cplusplus
 extern "C"
 #endif
+#include <openssl/ssl.h>
+#ifndef SSL_library_init
 char SSL_library_init ();
+#endif
 int
 main ()
 {
@@ -24994,4 +25010,3 @@ if test "$no_create" != yes; then
   # would make configure fail if this is the last instruction.
   $ac_cs_success || { (exit 1); exit 1; }
 fi
-

--- a/curses/cursesterm.c
+++ b/curses/cursesterm.c
@@ -21,9 +21,10 @@
  */
 #define _TN5250_TERMINAL_PRIVATE_DEFINED
 #include "tn5250-private.h"
-#include "cursesterm.h"
 
 #ifdef USE_CURSES
+#include "cursesterm.h"
+extern char *tgetstr();
 
 /* Some versions of ncurses don't have this defined. */
 #ifndef A_VERTICAL
@@ -325,7 +326,8 @@ static void curses_terminal_init(Tn5250Terminal * This)
    raw();
 
 #ifdef USE_OWN_KEY_PARSING
-   if ((str = (unsigned char *)tgetstr ("ks", NULL)) != NULL)
+   // if ((str = (unsigned char *)tgetstr ("ks", NULL)) != NULL)
+   if ((str = (char *)tgetstr ("ks", NULL)) != NULL)
       tputs (str, 1, putchar);
    fflush (stdout);
 #else
@@ -417,7 +419,8 @@ static void curses_terminal_init(Tn5250Terminal * This)
    s = sizeof (curses_vt100) / sizeof (Key);
    for (i = 0; i < c; i++) {
       This->data->k_map[i].k_code = curses_caps[i].k_code;
-      if ((str = (unsigned char *)tgetstr (curses_caps[i].k_str, NULL)) != NULL) {
+      // if ((str = (unsigned char *)tgetstr (curses_caps[i].k_str, NULL)) != NULL) {
+      if ((str = (char *)tgetstr (curses_caps[i].k_str, NULL)) != NULL) {
 	 TN5250_LOG(("Found string for cap '%s': '%s'.\n",
 		  curses_caps[i].k_str, str));
 	 strcpy (This->data->k_map[i].k_str, str);
@@ -442,7 +445,8 @@ static void curses_terminal_init(Tn5250Terminal * This)
    /* Damn the exceptions to the rules. (ESC + DEL) */
    This->data->k_map[This->data->k_map_len-1].k_code = K_INSERT;
    This->data->k_map[This->data->k_map_len-s-1].k_code = K_INSERT;
-   if ((str = (unsigned char *)tgetstr ("kD", NULL)) != NULL) {
+   // if ((str = (unsigned char *)tgetstr ("kD", NULL)) != NULL) {
+   if ((str = (char *)tgetstr ("kD", NULL)) != NULL) {
       This->data->k_map[This->data->k_map_len-1].k_str[0] = '\033';
       This->data->k_map[This->data->k_map_len-s-1].k_str[0] = K_CTRL('G');
       strcpy (This->data->k_map[This->data->k_map_len-1].k_str + 1, str);
@@ -640,9 +644,11 @@ static void curses_terminal_update(Tn5250Terminal * This, Tn5250Display *display
       if(This->data->is_xterm) {
          if (This->data->font_132!=NULL) {
                if (tn5250_display_width (display)>100)
-                    printf(This->data->font_132);
+                    // printf(This->data->font_132);
+                    printf("%s",This->data->font_132);
                else
-                    printf(This->data->font_80);
+                    // printf(This->data->font_80);
+                    printf("%s",This->data->font_80);
          }
 	 printf ("\x1b[8;%d;%dt", tn5250_display_height (display)+1,
 	       tn5250_display_width (display));

--- a/curses/tn5250.c
+++ b/curses/tn5250.c
@@ -19,6 +19,7 @@
  */
 
 #include "tn5250-private.h"
+#include "cursesterm.h"
 
 Tn5250Session *sess = NULL;
 Tn5250Stream *stream = NULL;

--- a/lib5250/sslstream.c
+++ b/lib5250/sslstream.c
@@ -369,15 +369,19 @@ int tn5250_ssl_stream_init (Tn5250Stream *This)
    }
 
    if (!strcmp(methstr, "ssl2")) {
-        meth = SSLv2_client_method();         
-        TN5250_LOG(("SSL Method = SSLv2_client_method()\n"));
+        TN5250_LOG(("SSL Method = SSL2 not supported, using TLS\n"));
+//        meth = SSLv2_client_method();         
+//        TN5250_LOG(("SSL Method = SSLv2_client_method()\n"));
    } else if (!strcmp(methstr, "ssl3")) {
-        meth = SSLv3_client_method();         
-        TN5250_LOG(("SSL Method = SSLv3_client_method()\n"));
+        TN5250_LOG(("SSL Method = SSL3 not supported, using TLS\n"));
+//        meth = SSLv3_client_method();         
+//        TN5250_LOG(("SSL Method = SSLv3_client_method()\n"));
    } else {
-        meth = SSLv23_client_method();         
-        TN5250_LOG(("SSL Method = SSLv23_client_method()\n"));
+        TN5250_LOG(("SSL Method = TLS_client_method()\n"));
+//        meth = SSLv23_client_method();         
+//        TN5250_LOG(("SSL Method = SSLv23_client_method()\n"));
    }
+   meth = TLS_client_method();
 
 /*  create a new SSL context */
 
@@ -1719,4 +1723,3 @@ X509 *ssl_stream_load_cert(Tn5250Stream *This, const char *file) {
 #endif /* HAVE_LIBSSL */
 
 /* vi:set sts=3 sw=3: */
-


### PR DESCRIPTION
I have made changes to fix the problem where tn5250 set faults on Mac OS X 64 bit and also updated the SSL code to recognize and work with OpenSSL version 1.1 and removed deprecated SSL connection methods. Please test build a Windows binary and send it to me. I do not have a Windows build environment setup. Thanks.