### PR TITLE
Fix exit from sometimes displaying a false error message.

### DIFF
--- a/configure
+++ b/configure
@@ -23246,12 +23246,6 @@ echo "${ECHO_T}$ac_cv_use_ssl" >&6; }
 
 if test "$ac_cv_use_ssl" = "yes"
 then
-#    cat >>confdefs.h <<_ACEOF
-##define HAVE_LIBSSL 1
-##define HAVE_LIBCRYPTO 1
-#_ACEOF
-#
-#    LIBS="-lssl -lcrypto $LIBS"
 checksslinclude() {
     if test -f "$1/include/openssl/ssl.h"; then
         sslincludedir="-I$1/include"
@@ -23325,7 +23319,7 @@ extern "C"
 #endif
 #include <openssl/crypto.h>
 #ifndef CRYPTO_num_locks
-char CRYPTO_num_locks ();
+int CRYPTO_num_locks ();
 #endif
 int
 main ()
@@ -23406,7 +23400,7 @@ extern "C"
 #endif
 #include <openssl/ssl.h>
 #ifndef SSL_library_init
-char SSL_library_init ();
+int SSL_library_init ();
 #endif
 int
 main ()

--- a/curses/tn5250.c
+++ b/curses/tn5250.c
@@ -156,6 +156,8 @@ int main(int argc, char *argv[])
    errno = 0;
 
 bomb_out:
+   if (errno != 0)
+      printf("Could not start session: %s\n", strerror(errno));
    if (macro != NULL)
       tn5250_macro_exit(macro);
    if (term != NULL)
@@ -166,9 +168,6 @@ bomb_out:
       tn5250_stream_destroy (stream);
    if (config != NULL)
       tn5250_config_unref (config);
-
-   if (errno != 0)
-      printf("Could not start session: %s\n", strerror(errno));
 #ifndef NDEBUG
    tn5250_log_close();
 #endif

--- a/lib5250/sslstream.c
+++ b/lib5250/sslstream.c
@@ -381,7 +381,11 @@ int tn5250_ssl_stream_init (Tn5250Stream *This)
 //        meth = SSLv23_client_method();         
 //        TN5250_LOG(("SSL Method = SSLv23_client_method()\n"));
    }
+#ifndef SSL_OP_NO_TLSv1_3
+   meth = SSLv23_client_method();
+#else
    meth = TLS_client_method();
+#endif
 
 /*  create a new SSL context */
 


### PR DESCRIPTION
On exiting with CTRL-Q under some conditions, the exit code would display a false error message like:
Could not start session: Too many levels of symbolic links
This was caused by one of the exit functions throwing an error when you are already in the process of exiting. The code might also have displayed the wrong message on a real error exit. Moving the error message printout to the beginning on the "bomb_out" assures that you display the actual error condition, if any, that caused the routine to be called.
